### PR TITLE
Add CodeOwners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @mapbox/gl-js


### PR DESCRIPTION
Hi team,

This PR adds a CODEOWNERS file to the repository.

The CODEOWNERS file defines the teams responsible for reviewing and approving changes to the repository. 
For more information, see the [GitHub documentation](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners).